### PR TITLE
Add option to use radio buttons instead of select for address picker

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -34,13 +34,16 @@
 }
 
 .woocommerce-checkout .address_book input.input-radio {
-	display: block;
-	float: left;
-	margin-bottom: 3px;
 	margin-right: 15px;
+	margin-bottom: 1em;
+	margin-top: 1em;
 }
 
 .woocommerce-checkout .address_book label.radio {
-	line-height: 1;
-	margin-bottom: 1em;
+	display: inline;
+}
+
+.woocommerce-checkout .address_book label.radio::after {
+	content: '\A';
+	white-space: pre;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -32,3 +32,15 @@
 .woocommerce-account .address-book .wc-address-book-meta a:hover {
 	cursor: pointer;
 }
+
+.woocommerce-checkout .address_book input.input-radio {
+	display: block;
+	float: left;
+	margin-bottom: 3px;
+	margin-right: 15px;
+}
+
+.woocommerce-checkout .address_book label.radio {
+	line-height: 1;
+	margin-bottom: 1em;
+}

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -17,6 +17,10 @@ var woo_address_book_app = {
 		var $ = this.jQuery;
 		var load_selectWoo = true;
 		var address_book = $( 'select#shipping_address_book:visible, select#billing_address_book:visible' );
+		if ( ! address_book.length ) {
+			address_book = $( 'input[name="shipping_address_book"]:checked, input[name="billing_address_book"]:checked' );
+			load_selectWoo = false;
+		}
 
 		// Check for Selectize being used.
 		if ( $.fn.selectize ) {
@@ -42,7 +46,7 @@ var woo_address_book_app = {
 		woo_address_book_app.checkout_field_prepop( 'billing', true );
 
 		// Retrieves billing address when another is selected.
-		$( document ).on( 'change', '#billing_address_book_field #billing_address_book', function () {
+		$( document ).on( 'change', '#billing_address_book_field #billing_address_book, #billing_address_book_field input[name="billing_address_book"]:checked', function () {
 			woo_address_book_app.checkout_field_prepop( 'billing', false );
 		} );
 
@@ -60,7 +64,7 @@ var woo_address_book_app = {
 		woo_address_book_app.checkout_field_prepop( 'shipping', true );
 
 		// Retrieves shipping address when another is selected.
-		$( document ).on( 'change', '#shipping_address_book_field #shipping_address_book', function () {
+		$( document ).on( 'change', '#shipping_address_book_field #shipping_address_book, #shipping_address_book_field input[name="shipping_address_book"]:checked', function () {
 			woo_address_book_app.checkout_field_prepop( 'shipping', false );
 		} );
 
@@ -171,6 +175,9 @@ var woo_address_book_app = {
 			return;
 		}
 		let that = $( '#' + address_type + '_address_book_field #' + address_type + '_address_book' );
+		if ( ! that.length ) {
+			that = $( '#' + address_type + '_address_book_field input[name="' + address_type + '_address_book"]:checked' );
+		}
 
 		let name = $( that ).val();
 
@@ -179,7 +186,7 @@ var woo_address_book_app = {
 			if ( 'add_new' === name ) {
 
 				// Clear values when adding a new address.
-				$( '.woocommerce-' + address_type + '-fields__field-wrapper input' ).not( $( '#' + address_type + '_country' ) ).not( '#' + address_type + '_address_book' ).each( function () {
+				$( '.woocommerce-' + address_type + '-fields__field-wrapper input' ).not( $( '#' + address_type + '_country' ) ).not( '#' + address_type + '_address_book' ).not( '[name="' + address_type + '_address_book"]' ).each( function () {
 					var input = $( this );
 					if ( input.attr("type") === "checkbox" || input.attr("type") === "radio") {
 						input.prop( "checked", false );
@@ -240,6 +247,7 @@ var woo_address_book_app = {
 							// If entered values do not equal shipping calculator values
 							if ( shipping_country_o !== response.shipping_country || shipping_state_o !== response.shipping_state || shipping_city_o !== response.shipping_city || shipping_postcode_o !== response.shipping_postcode ) {
 								$( "#shipping_address_book" ).val( 'add_new' ).trigger( 'change' );
+								$( 'input#shipping_address_book_add_new').prop( 'checked', true ).trigger( 'change' );
 								return;
 							}
 						}

--- a/includes/class-wc-address-book.php
+++ b/includes/class-wc-address-book.php
@@ -198,7 +198,7 @@ class WC_Address_Book {
 			)
 		);
 
-		if ( is_account_page() ) {
+		if ( is_account_page() || is_checkout() ) {
 			wp_enqueue_style( 'woo-address-book' );
 		}
 
@@ -669,9 +669,14 @@ class WC_Address_Book {
 					$address_book = $this->get_address_book( null, $type );
 					$under_limit  = $this->limit_saved_addresses( $type );
 
+					$select_type = 'select';
+					if ( $this->get_wcab_option( 'use_radio_input', 'no' ) === true ) {
+						$select_type = 'radio';
+					}
+
 					$address_selector                            = array();
 					$address_selector[ $type . '_address_book' ] = array(
-						'type'     => 'select',
+						'type'     => $select_type,
 						'class'    => array( 'form-row-wide', 'address_book' ),
 						'label'    => __( 'Address Book', 'woo-address-book' ),
 						'order'    => -1,

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -102,6 +102,13 @@ function woo_address_book_general_settings( $settings ) {
 	);
 
 	$settings[] = array(
+		'desc'    => __( 'Use radio inputs instead of a select element for billing/shipping address on checkout.', 'woo-address-book' ),
+		'id'      => 'woo_address_book_use_radio_input',
+		'default' => 'no',
+		'type'    => 'checkbox',
+	);
+
+	$settings[] = array(
 		'type' => 'sectionend',
 		'id'   => 'woo_address_book_options',
 	);


### PR DESCRIPTION
Implements an option to set radio buttons instead of select if required. Closes https://github.com/crosspeaksoftware/woo-address-book/issues/146