### PR TITLE
set default with the set_default function

### DIFF
--- a/includes/class-address-book.php
+++ b/includes/class-address-book.php
@@ -263,7 +263,7 @@ class Address_Book {
 		$this->address_keys[] = $key;
 		$this->update_address_meta( $key, $address );
 		if ( $as_default ) {
-			$this->default = $key;
+			$this->set_default( $key );
 		}
 		$this->update_address_book_meta();
 		return $key;


### PR DESCRIPTION
set default with the set_default function to properly save to woo instead of just setting the key

Fixes #162