### PR TITLE
refactor out limit addresses to the Address Book class 

### DIFF
--- a/includes/class-address-book.php
+++ b/includes/class-address-book.php
@@ -240,6 +240,82 @@ class Address_Book {
 	}
 
 	/**
+	 * Get the current address limit.
+	 * Use 0 for unlimited.
+	 *
+	 * @return int
+	 */
+	public function limit() {
+		$save_limit = (int) get_option( 'woo_address_book_' . $this->type . '_save_limit', 0 );
+		/**
+		 * Filters the number of saved addresses.
+		 *
+		 * @since 3.1.0
+		 * @param int $save_limit Number of addresses that are able to be saved.
+		 * @param string $type - 'billing' or 'shipping'.
+		 *
+		 * @return int Use 0 for unlimited.
+		 */
+		return (int) apply_filters( 'woo_address_book_limit', $save_limit, $this->type );
+	}
+
+	/**
+	 * Check if we are under the address limit.
+	 *
+	 * @return bool
+	 */
+	public function is_under_limit() {
+		/**
+		 * Filters whether we are under the address limit.
+		 *
+		 * @since 3.1.0
+		 * @param ?boolean $preempt Whether to preempt the limit. Default null.
+		 * @param string $type - 'billing' or 'shipping'.
+		 *
+		 * @return ?boolean true if under the limit, false if over. null to continue checking as normal.
+		 */
+		$preempt = apply_filters( 'woo_address_book_is_under_limit', null, $this->type );
+		if ( ! is_null( $preempt ) ) {
+			return $preempt;
+		}
+		$save_limit = $this->limit();
+		if ( empty( $save_limit ) ) {
+			return true;
+		}
+		if ( $this->count() < $save_limit ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Get the current Address book type.
+	 *
+	 * @return string
+	 */
+	public function type() {
+		return $this->type;
+	}
+
+	/**
+	 * Check if the address book is for billing.
+	 *
+	 * @return boolean
+	 */
+	public function is_billing() {
+		return 'billing' === $this->type;
+	}
+
+	/**
+	 * Check if the address book is for shipping.
+	 *
+	 * @return boolean
+	 */
+	public function is_shipping() {
+		return 'shipping' === $this->type;
+	}
+
+	/**
 	 * Save the address to the customer's profile
 	 *
 	 * @param string $key The key of the address.

--- a/templates/myaccount/add-address-button.php
+++ b/templates/myaccount/add-address-button.php
@@ -17,7 +17,6 @@
 namespace CrossPeakSoftware\WooCommerce\AddressBook\Templates\AddAddressButton;
 
 use function CrossPeakSoftware\WooCommerce\AddressBook\get_address_book_endpoint_url;
-use function CrossPeakSoftware\WooCommerce\AddressBook\limit_saved_addresses;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -26,42 +25,41 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Template variables:
  *
- * @var string $woo_address_book_address_type 'billing' or 'shipping'.
+ * @var \CrossPeakSoftware\WooCommerce\AddressBook\Address_Book $woo_address_book The current address book.
  */
 
-$woo_address_book_add_button_classes = 'add button wc-address-book-add-' . $woo_address_book_address_type . '-button';
-$woo_address_book_under_limit        = limit_saved_addresses( $woo_address_book_address_type );
+$woo_address_book_add_button_classes = 'add button wc-address-book-add-' . $woo_address_book->type() . '-button';
 ?>
 <div class="wc-address-book-add-new-address add-new-address">
 	<span
 		class="<?php echo esc_attr( $woo_address_book_add_button_classes ); ?> disabled"
 			<?php
-			if ( $woo_address_book_under_limit ) {
+			if ( $woo_address_book->is_under_limit() ) {
 				echo 'style="display:none"';
 			}
 			?>
 		>
 		<?php
-		if ( 'billing' === $woo_address_book_address_type ) {
+		if ( $woo_address_book->is_billing() ) {
 			echo esc_html__( 'Billing Address Book Full', 'woo-address-book' );
-		} elseif ( 'shipping' === $woo_address_book_address_type ) {
+		} elseif ( $woo_address_book->is_shipping() ) {
 			echo esc_html__( 'Shipping Address Book Full', 'woo-address-book' );
 		}
 		?>
 	</span>
 	<a
-		href="<?php echo esc_url( get_address_book_endpoint_url( 'new', $woo_address_book_address_type ) ); ?>"
+		href="<?php echo esc_url( get_address_book_endpoint_url( 'new', $woo_address_book->type() ) ); ?>"
 		class="<?php echo esc_attr( $woo_address_book_add_button_classes ); ?>"
 			<?php
-			if ( ! $woo_address_book_under_limit ) {
+			if ( ! $woo_address_book->is_under_limit() ) {
 				echo 'style="display:none"';
 			}
 			?>
 		>
 		<?php
-		if ( 'billing' === $woo_address_book_address_type ) {
+		if ( $woo_address_book->is_billing() ) {
 			echo esc_html__( 'Add New Billing Address', 'woo-address-book' );
-		} elseif ( 'shipping' === $woo_address_book_address_type ) {
+		} elseif ( $woo_address_book->is_shipping() ) {
 			echo esc_html__( 'Add New Shipping Address', 'woo-address-book' );
 		}
 		?>

--- a/templates/myaccount/my-address-book.php
+++ b/templates/myaccount/my-address-book.php
@@ -37,7 +37,7 @@ if ( setting( 'billing_enable' ) === true ) {
 
 	// Hide the billing address book if there are no addresses to show and no ability to add new ones.
 	$woo_address_book_count_section = $woo_address_book_billing_address_book->count();
-	$woo_address_book_save_limit    = (int) get_option( 'woo_address_book_billing_save_limit', 0 );
+	$woo_address_book_save_limit    = $woo_address_book_billing_address_book->limit();
 
 	if ( 1 === $woo_address_book_save_limit && $woo_address_book_billing_address_book->count() <= 1 ) {
 		$woo_address_book_hide_billing_address_book = true;
@@ -61,17 +61,17 @@ if ( setting( 'billing_enable' ) === true ) {
 				<?php
 				$woo_address_book_billing_description = esc_html( __( 'The following billing addresses are available during the checkout process. ', 'woo-address-book' ) );
 
-				if ( $woo_address_book_save_limit > 1 ) {
+				if ( $woo_address_book_save_limit > 0 ) {
 					$woo_address_book_billing_description .= ' ' . esc_html(
 						sprintf(
 							/* translators: %1s: The number of addresses that can be saved. */
 							_n(
-								'You can save a maximum of %1s address in addition to the default.',
-								'You can save a maximum of %1s addresses in addition to the default.',
-								$woo_address_book_save_limit - 1,
+								'You can save a maximum of %1s address.',
+								'You can save a maximum of %1s addresses.',
+								$woo_address_book_save_limit,
 								'woo-address-book'
 							),
-							$woo_address_book_save_limit - 1
+							$woo_address_book_save_limit
 						)
 					);
 
@@ -148,7 +148,7 @@ if ( setting( 'shipping_enable' ) === true ) {
 
 	// Hide the billing address book if there are no addresses to show and no ability to add new ones.
 	$woo_address_book_count_section = $woo_address_book_shipping_address_book->count();
-	$woo_address_book_save_limit    = (int) get_option( 'woo_address_book_shipping_save_limit', 0 );
+	$woo_address_book_save_limit    = $woo_address_book_shipping_address_book->limit();
 
 	if ( 1 === $woo_address_book_save_limit && $woo_address_book_count_section <= 1 ) {
 		$woo_address_book_hide_shipping_address_book = true;
@@ -173,17 +173,17 @@ if ( setting( 'shipping_enable' ) === true ) {
 				<?php
 				$woo_address_book_shipping_description = esc_html( __( 'The following shipping addresses are available during the checkout process.', 'woo-address-book' ) );
 
-				if ( $woo_address_book_save_limit > 1 ) {
+				if ( $woo_address_book_save_limit > 0 ) {
 					$woo_address_book_shipping_description .= ' ' . esc_html(
 						sprintf(
 							/* translators: %1s: The number of addresses that can be saved. */
 							_n(
-								'You can save a maximum of %1s address in addition to the default.',
-								'You can save a maximum of %1s addresses in addition to the default.',
-								$woo_address_book_save_limit - 1,
+								'You can save a maximum of %1s address.',
+								'You can save a maximum of %1s addresses.',
+								$woo_address_book_save_limit,
 								'woo-address-book'
 							),
-							$woo_address_book_save_limit - 1
+							$woo_address_book_save_limit
 						)
 					);
 


### PR DESCRIPTION
enforce limit on address save.

This adds two new filters that can be used.

```php
/**
 * Filters the number of saved addresses.
 *
 * @since 3.1.0
 * @param int $save_limit Number of addresses that are able to be saved.
 * @param string $type - 'billing' or 'shipping'.
 *
 * @return int Use 0 for unlimited.
 */
add_filters( 'woo_address_book_limit', function ( $save_limit, $type ) {
	return $save_limit;
} );

/**
 * Filters whether we are under the address limit.
 *
 * @since 3.1.0
 * @param ?boolean $preempt Whether to preempt the limit. Default null.
 * @param string $type - 'billing' or 'shipping'.
 *
 * @return ?boolean true if under the limit, false if over. null to continue checking as normal.
 */
add_filters( 'woo_address_book_is_under_limit', function ( $preempt, $type ) {
	return $preempt;
} );
```

Fixes #157